### PR TITLE
Add --dry-run & -n options

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,21 +1,28 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import print_function, unicode_literals
 from datetime import date
 
 from channels.backends.twitter import TwitterChannel
+import click
 import dateutil.parser
 import requests
 
 from conf import config
 
 
-def main():
+@click.command(help="CAMPHOR- Schedule Notifier")
+@click.option("--dry-run", "-n", default=False, is_flag=True,
+              help="Write messages to stdout.")
+def main(dry_run):
     events = download_events(config["url"])
     if events is None:
         return
     events = get_todays_events(events)
     events = get_open_events(events)
     message = generate_message(events)
+    if dry_run:
+        print(message)
+        return
     channel = TwitterChannel(**config["twitter"])
     channel.send(message)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+click==6.7
 django-channels==0.4.0
 python-dateutil==2.4.2


### PR DESCRIPTION
動作例:
```
./app.py:15: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  help="Write messages to stdout.")
./app.py:61: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  main()
本日の CAMPHOR- HOUSE の開館時間は15:00〜19:00です。
みなさんのお越しをお待ちしています!!
```