### PR TITLE
Tweets weekly schedule once a week

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,8 @@ import locale
 import pytz
 import requests
 
+WEEKDAY_NAMES = ['月', '火', '水', '木', '金', '土', '日']
+
 
 class Event:
     start: datetime
@@ -58,6 +60,10 @@ class Event:
             return None
 
 
+def get_japanese_weekday(day: int) -> str:
+    return WEEKDAY_NAMES[day]
+
+
 def generate_week_message(events: List[Event], tz: tzinfo) -> List[str]:
     locale.setlocale(locale.LC_TIME, 'ja_JP.UTF-8')
     open_events = list(filter(lambda e: e.title.lower() == "open", events))
@@ -70,7 +76,7 @@ def generate_week_message(events: List[Event], tz: tzinfo) -> List[str]:
         open_message = "今週の開館日です！\n"
         for open in open_events:
             date = open.start.astimezone(tz).date().strftime("%m/%d")
-            day = open.start.astimezone(tz).strftime("%a")
+            day = get_japanese_weekday(open.start.astimezone(tz).weekday())
             start = open.start.astimezone(tz).time().strftime("%H:%M")
             end = open.end.astimezone(tz).time().strftime("%H:%M")
             open_message += f"{date} ({day}) {start}〜{end}\n"
@@ -81,7 +87,7 @@ def generate_week_message(events: List[Event], tz: tzinfo) -> List[str]:
         other_message = "今週のイベント情報です！\n"
         for event in other_events:
             date = event.start.astimezone(tz).date().strftime("%m/%d")
-            day = event.start.astimezone(tz).strftime("%a")
+            day = get_japanese_weekday(event.start.astimezone(tz).weekday())
             start = event.start.astimezone(tz).time().strftime("%H:%M")
             end = event.end.astimezone(tz).time().strftime("%H:%M")
             other_message += f"{event.title} {date} ({day}) {start}〜{end}\n"

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable, List, Optional
 import click
 import dateutil.parser
 from kawasemi import Kawasemi
+import locale
 import pytz
 import requests
 
@@ -58,6 +59,7 @@ class Event:
 
 
 def generate_week_message(events: List[Event], tz: tzinfo) -> List[str]:
+    locale.setlocale(locale.LC_TIME, 'ja_JP.UTF-8')
     open_events = list(filter(lambda e: e.title.lower() == "open", events))
     other_events = list(
         filter(lambda e: e.title.lower() != "open", events))
@@ -68,9 +70,10 @@ def generate_week_message(events: List[Event], tz: tzinfo) -> List[str]:
         open_message = "今週の開館日です！\n"
         for open in open_events:
             date = open.start.astimezone(tz).date().strftime("%m/%d")
+            day = open.start.astimezone(tz).strftime("%a")
             start = open.start.astimezone(tz).time().strftime("%H:%M")
             end = open.end.astimezone(tz).time().strftime("%H:%M")
-            open_message += f"{date} {start}〜{end}\n"
+            open_message += f"{date} ({day}) {start}〜{end}\n"
         open_message += "\nみなさんのお越しをお待ちしています!!"
         messages.append(open_message)
 
@@ -78,9 +81,11 @@ def generate_week_message(events: List[Event], tz: tzinfo) -> List[str]:
         other_message = "今週のイベント情報です！\n"
         for event in other_events:
             date = event.start.astimezone(tz).date().strftime("%m/%d")
+            day = event.start.astimezone(tz).strftime("%a")
             start = event.start.astimezone(tz).time().strftime("%H:%M")
             end = event.end.astimezone(tz).time().strftime("%H:%M")
-            other_message += f"{event.title} {date} {start}〜{end}\n"
+            other_message += f"{event.title} {date} ({day}) {start}〜{end}\n"
+        other_message += "\nお申し込みの上ご参加ください。"
         other_message += "\nみなさんのお越しをお待ちしています!!"
         messages.append(other_message)
 

--- a/app.py
+++ b/app.py
@@ -5,7 +5,6 @@ from typing import Dict, Iterable, List, Optional
 import click
 import dateutil.parser
 from kawasemi import Kawasemi
-import locale
 import pytz
 import requests
 
@@ -65,7 +64,6 @@ def get_japanese_weekday(day: int) -> str:
 
 
 def generate_week_message(events: List[Event], tz: tzinfo) -> List[str]:
-    locale.setlocale(locale.LC_TIME, 'ja_JP.UTF-8')
     open_events = list(filter(lambda e: e.title.lower() == "open", events))
     other_events = list(
         filter(lambda e: e.title.lower() != "open", events))

--- a/app.py
+++ b/app.py
@@ -85,6 +85,8 @@ def generate_week_message(events: List[Event], tz: tzinfo) -> List[str]:
             start = event.start.astimezone(tz).time().strftime("%H:%M")
             end = event.end.astimezone(tz).time().strftime("%H:%M")
             other_message += f"{event.title} {date} ({day}) {start}〜{end}\n"
+            if event.url is not None:
+                other_message += f"{event.url}\n"
         other_message += "\nお申し込みの上ご参加ください。"
         other_message += "\nみなさんのお越しをお待ちしています!!"
         messages.append(other_message)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -90,3 +90,69 @@ https://example.com/"""
             title="")
         message = e.generate_message(datetime(2017, 3, 3, 10, tzinfo=tz))
         assert message is None
+
+    def test_generate_week_message_with_open(self):
+        tz = pytz.timezone("Asia/Tokyo")
+        e0 = app.Event(
+            start=datetime(2019, 4, 1, 17, tzinfo=tz),
+            end=datetime(2019, 4, 1, 19, tzinfo=tz),
+            url=None,
+            title="Open")
+        e1 = app.Event(
+            start=datetime(2019, 4, 3, 17, tzinfo=tz),
+            end=datetime(2019, 4, 3, 19, tzinfo=tz),
+            url=None,
+            title="Open")
+        message = app.generate_week_message([e0, e1], tz)
+        assert message == ["""今週の開館日です！
+04/01 17:00〜19:00
+04/03 17:00〜19:00
+
+みなさんのお越しをお待ちしています!!"""]
+
+    def test_generate_week_message_with_event(self):
+        tz = pytz.timezone("Asia/Tokyo")
+        e0 = app.Event(
+            start=datetime(2019, 4, 2, 17, tzinfo=tz),
+            end=datetime(2019, 4, 2, 19, tzinfo=tz),
+            url=None,
+            title="Python Event")
+        message = app.generate_week_message([e0], tz)
+        assert message == ["""今週のイベント情報です！
+Python Event 04/02 17:00〜19:00
+
+みなさんのお越しをお待ちしています!!"""]
+
+    def test_generate_week_message_with_nothing(self):
+        tz = pytz.timezone("Asia/Tokyo")
+        message = app.generate_week_message([], tz)
+        assert message == []
+
+    def test_generate_week_message_with_event_and_open(self):
+        tz = pytz.timezone("Asia/Tokyo")
+        e0 = app.Event(
+            start=datetime(2019, 4, 2, 17, tzinfo=tz),
+            end=datetime(2019, 4, 2, 19, tzinfo=tz),
+            url=None,
+            title="Python Event")
+        e1 = app.Event(
+            start=datetime(2019, 4, 1, 17, tzinfo=tz),
+            end=datetime(2019, 4, 1, 19, tzinfo=tz),
+            url=None,
+            title="Open")
+        e2 = app.Event(
+            start=datetime(2019, 4, 3, 17, tzinfo=tz),
+            end=datetime(2019, 4, 3, 19, tzinfo=tz),
+            url=None,
+            title="Open")
+
+        message = app.generate_week_message([e0, e1, e2], tz)
+        assert message == ["""今週の開館日です！
+04/01 17:00〜19:00
+04/03 17:00〜19:00
+
+みなさんのお越しをお待ちしています!!""",
+                           """今週のイベント情報です！
+Python Event 04/02 17:00〜19:00
+
+みなさんのお越しをお待ちしています!!"""]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -105,8 +105,8 @@ https://example.com/"""
             title="Open")
         message = app.generate_week_message([e0, e1], tz)
         assert message == ["""今週の開館日です！
-04/01 17:00〜19:00
-04/03 17:00〜19:00
+04/01 (月) 17:00〜19:00
+04/03 (水) 17:00〜19:00
 
 みなさんのお越しをお待ちしています!!"""]
 
@@ -119,8 +119,9 @@ https://example.com/"""
             title="Python Event")
         message = app.generate_week_message([e0], tz)
         assert message == ["""今週のイベント情報です！
-Python Event 04/02 17:00〜19:00
+Python Event 04/02 (火) 17:00〜19:00
 
+お申し込みの上ご参加ください。
 みなさんのお越しをお待ちしています!!"""]
 
     def test_generate_week_message_with_nothing(self):
@@ -148,11 +149,12 @@ Python Event 04/02 17:00〜19:00
 
         message = app.generate_week_message([e0, e1, e2], tz)
         assert message == ["""今週の開館日です！
-04/01 17:00〜19:00
-04/03 17:00〜19:00
+04/01 (月) 17:00〜19:00
+04/03 (水) 17:00〜19:00
 
 みなさんのお越しをお待ちしています!!""",
                            """今週のイベント情報です！
-Python Event 04/02 17:00〜19:00
+Python Event 04/02 (火) 17:00〜19:00
 
+お申し込みの上ご参加ください。
 みなさんのお越しをお待ちしています!!"""]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -134,7 +134,7 @@ Python Event 04/02 (火) 17:00〜19:00
         e0 = app.Event(
             start=datetime(2019, 4, 2, 17, tzinfo=tz),
             end=datetime(2019, 4, 2, 19, tzinfo=tz),
-            url=None,
+            url='https://example.com/',
             title="Python Event")
         e1 = app.Event(
             start=datetime(2019, 4, 1, 17, tzinfo=tz),
@@ -155,6 +155,7 @@ Python Event 04/02 (火) 17:00〜19:00
 みなさんのお越しをお待ちしています!!""",
                            """今週のイベント情報です！
 Python Event 04/02 (火) 17:00〜19:00
+https://example.com/
 
 お申し込みの上ご参加ください。
 みなさんのお越しをお待ちしています!!"""]


### PR DESCRIPTION
## WHAT

一週間の開館日、イベントをまとめてツイッターに流す
#24 での機能追加

`CSN_WEEK` の環境変数が 1 に設定されている状態で起動すると一週間分のスケジュールがツイートされる。 (設定されていないときには今まで通りその日の開館時間、イベントを通知する。)

## WHY

当日に開館日であることを知っても予定が合わない場合が多い
https://github.com/camphor-/tasks/issues/1090 などを参照のこと

## TODO

- [x] テストの作成
- [ ] Rundeck 上での設定変更