### PR TITLE
スケジュールページへのリンクをツイートに追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,10 +52,14 @@ class Event:
         if self.title.lower() == "open":
             return f"""本日の CAMPHOR- HOUSE の開館時間は{start}〜{end}です。
 みなさんのお越しをお待ちしています!!
+
+その他の開館日はこちら
 {SCHEDULE_LINK}"""
         elif self.title.lower() == "online open":
             return f"""本日の CAMPHOR- HOUSE のオンライン開館時間は{start}〜{end}です。
 詳しくはCAMPHOR-のSlackをご覧ください!!
+
+その他の開館日はこちら
 {SCHEDULE_LINK}"""
         elif self.title.strip() != "":
             message = f"""「{self.title}」を{start}〜{end}に開催します!
@@ -120,7 +124,7 @@ def generate_open_event_message(open_events: List[Event], tz: tzinfo) -> str:
     message = "今週の開館日です！\n"
     for open in open_events:
         message += open.get_day_and_time(tz)
-    message += "\nみなさんのお越しをお待ちしています!!"
+    message += "\nみなさんのお越しをお待ちしています!!\n\nその他の開館日はこちら"
     return add_schedule_link(message)
 
 
@@ -132,7 +136,7 @@ def generate_online_open_event_message(
     message = "今週のオンライン開館日です！\n"
     for online in online_open_events:
         message += online.get_day_and_time(tz)
-    message += "\n詳しくはCAMPHOR-のSlackをご覧ください!!"
+    message += "\n詳しくはCAMPHOR-のSlackをご覧ください!!\n\nその他の開館日はこちら"
     return add_schedule_link(message)
 
 

--- a/app.py
+++ b/app.py
@@ -10,6 +10,8 @@ import requests
 
 WEEKDAY_NAMES = ['月', '火', '水', '木', '金', '土', '日']
 
+SCHEDULE_LINK = 'https://camph.net/schedule/'
+
 
 class Event:
     start: datetime
@@ -49,10 +51,12 @@ class Event:
 
         if self.title.lower() == "open":
             return f"""本日の CAMPHOR- HOUSE の開館時間は{start}〜{end}です。
-みなさんのお越しをお待ちしています!!"""
+みなさんのお越しをお待ちしています!!
+{SCHEDULE_LINK}"""
         elif self.title.lower() == "online open":
             return f"""本日の CAMPHOR- HOUSE のオンライン開館時間は{start}〜{end}です。
-詳しくはCAMPHOR-のSlackをご覧ください!!"""
+詳しくはCAMPHOR-のSlackをご覧ください!!
+{SCHEDULE_LINK}"""
         elif self.title.strip() != "":
             message = f"""「{self.title}」を{start}〜{end}に開催します!
 みなさんのお越しをお待ちしています!!"""
@@ -105,6 +109,10 @@ def generate_week_message(events: List[Event], tz: tzinfo) -> List[str]:
     return messages
 
 
+def add_schedule_link(message: str) -> str:
+    return f"{message}\n{SCHEDULE_LINK}"
+
+
 def generate_open_event_message(open_events: List[Event], tz: tzinfo) -> str:
     if len(open_events) == 0:
         return ""
@@ -113,7 +121,7 @@ def generate_open_event_message(open_events: List[Event], tz: tzinfo) -> str:
     for open in open_events:
         message += open.get_day_and_time(tz)
     message += "\nみなさんのお越しをお待ちしています!!"
-    return message
+    return add_schedule_link(message)
 
 
 def generate_online_open_event_message(
@@ -125,7 +133,7 @@ def generate_online_open_event_message(
     for online in online_open_events:
         message += online.get_day_and_time(tz)
     message += "\n詳しくはCAMPHOR-のSlackをご覧ください!!"
-    return message
+    return add_schedule_link(message)
 
 
 def generate_other_event_message(other_events: List[Event], tz: tzinfo) -> str:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,8 @@ import pytz
 
 import app
 
+SCHEDULE_LINK = 'https://camph.net/schedule/'
+
 
 class TestEvent:
     def test_from_json(self):
@@ -59,8 +61,9 @@ class TestEvent:
             url=None,
             title="Open")
         message = e.generate_message(datetime(2017, 3, 3, 10, tzinfo=tz))
-        assert message == """本日の CAMPHOR- HOUSE の開館時間は15:00〜19:00です。
-みなさんのお越しをお待ちしています!!"""
+        assert message == f"""本日の CAMPHOR- HOUSE の開館時間は15:00〜19:00です。
+みなさんのお越しをお待ちしています!!
+{SCHEDULE_LINK}"""
 
         e = app.Event(
             start=datetime(2020, 4, 12, 15, tzinfo=tz),
@@ -68,8 +71,9 @@ class TestEvent:
             url=None,
             title="Online Open")
         message = e.generate_message(datetime(2020, 4, 12, 10, tzinfo=tz))
-        assert message == """本日の CAMPHOR- HOUSE のオンライン開館時間は15:00〜19:00です。
-詳しくはCAMPHOR-のSlackをご覧ください!!"""
+        assert message == f"""本日の CAMPHOR- HOUSE のオンライン開館時間は15:00〜19:00です。
+詳しくはCAMPHOR-のSlackをご覧ください!!
+{SCHEDULE_LINK}"""
 
         e = app.Event(
             start=datetime(2017, 3, 3, 17, tzinfo=tz),
@@ -113,11 +117,12 @@ https://example.com/"""
             url=None,
             title="Open")
         message = app.generate_week_message([e0, e1], tz)
-        assert message == ["""今週の開館日です！
+        assert message == [f"""今週の開館日です！
 04/01 (月) 17:00〜19:00
 04/03 (水) 17:00〜19:00
 
-みなさんのお越しをお待ちしています!!"""]
+みなさんのお越しをお待ちしています!!
+{SCHEDULE_LINK}"""]
 
     def test_generate_week_message_with_online_open(self):
         tz = pytz.timezone("Asia/Tokyo")
@@ -132,11 +137,12 @@ https://example.com/"""
             url=None,
             title="Online Open")
         message = app.generate_week_message([e0, e1], tz)
-        assert message == ["""今週のオンライン開館日です！
+        assert message == [f"""今週のオンライン開館日です！
 04/01 (水) 17:00〜19:00
 04/03 (金) 17:00〜19:00
 
-詳しくはCAMPHOR-のSlackをご覧ください!!"""]
+詳しくはCAMPHOR-のSlackをご覧ください!!
+{SCHEDULE_LINK}"""]
 
     def test_generate_week_message_with_event(self):
         tz = pytz.timezone("Asia/Tokyo")
@@ -176,11 +182,12 @@ Python Event 04/02 (火) 17:00〜19:00
             title="Open")
 
         message = app.generate_week_message([e0, e1, e2], tz)
-        assert message == ["""今週の開館日です！
+        assert message == [f"""今週の開館日です！
 04/01 (月) 17:00〜19:00
 04/03 (水) 17:00〜19:00
 
-みなさんのお越しをお待ちしています!!""",
+みなさんのお越しをお待ちしています!!
+{SCHEDULE_LINK}""",
                            """今週のイベント情報です！
 Python Event 04/02 (火) 17:00〜19:00
 https://example.com/
@@ -212,15 +219,17 @@ https://example.com/
             title="Online Open")
 
         message = app.generate_week_message([e0, e1, e2, e3], tz)
-        assert message == ["""今週の開館日です！
+        assert message == [f"""今週の開館日です！
 04/01 (月) 17:00〜19:00
 04/03 (水) 17:00〜19:00
 
-みなさんのお越しをお待ちしています!!""",
-                           """今週のオンライン開館日です！
+みなさんのお越しをお待ちしています!!
+{SCHEDULE_LINK}""",
+                           f"""今週のオンライン開館日です！
 04/04 (木) 17:00〜19:00
 
-詳しくはCAMPHOR-のSlackをご覧ください!!""",
+詳しくはCAMPHOR-のSlackをご覧ください!!
+{SCHEDULE_LINK}""",
                            """今週のイベント情報です！
 Python Event 04/02 (火) 17:00〜19:00
 https://example.com/

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -63,6 +63,8 @@ class TestEvent:
         message = e.generate_message(datetime(2017, 3, 3, 10, tzinfo=tz))
         assert message == f"""本日の CAMPHOR- HOUSE の開館時間は15:00〜19:00です。
 みなさんのお越しをお待ちしています!!
+
+その他の開館日はこちら
 {SCHEDULE_LINK}"""
 
         e = app.Event(
@@ -73,6 +75,8 @@ class TestEvent:
         message = e.generate_message(datetime(2020, 4, 12, 10, tzinfo=tz))
         assert message == f"""本日の CAMPHOR- HOUSE のオンライン開館時間は15:00〜19:00です。
 詳しくはCAMPHOR-のSlackをご覧ください!!
+
+その他の開館日はこちら
 {SCHEDULE_LINK}"""
 
         e = app.Event(
@@ -122,6 +126,8 @@ https://example.com/"""
 04/03 (水) 17:00〜19:00
 
 みなさんのお越しをお待ちしています!!
+
+その他の開館日はこちら
 {SCHEDULE_LINK}"""]
 
     def test_generate_week_message_with_online_open(self):
@@ -142,6 +148,8 @@ https://example.com/"""
 04/03 (金) 17:00〜19:00
 
 詳しくはCAMPHOR-のSlackをご覧ください!!
+
+その他の開館日はこちら
 {SCHEDULE_LINK}"""]
 
     def test_generate_week_message_with_event(self):
@@ -187,6 +195,8 @@ Python Event 04/02 (火) 17:00〜19:00
 04/03 (水) 17:00〜19:00
 
 みなさんのお越しをお待ちしています!!
+
+その他の開館日はこちら
 {SCHEDULE_LINK}""",
                            """今週のイベント情報です！
 Python Event 04/02 (火) 17:00〜19:00
@@ -224,11 +234,15 @@ https://example.com/
 04/03 (水) 17:00〜19:00
 
 みなさんのお越しをお待ちしています!!
+
+その他の開館日はこちら
 {SCHEDULE_LINK}""",
                            f"""今週のオンライン開館日です！
 04/04 (木) 17:00〜19:00
 
 詳しくはCAMPHOR-のSlackをご覧ください!!
+
+その他の開館日はこちら
 {SCHEDULE_LINK}""",
                            """今週のイベント情報です！
 Python Event 04/02 (火) 17:00〜19:00


### PR DESCRIPTION
## 概要

issue: スケジュールページへのリンクをツイートに追加 #2

## 変更内容

- 通常開館・オンライン開館当日のツイートにスケジュールページへのリンクを加える
- 通常開館・オンライン開館の1週間分ツイートにスケジュールページへのリンクを加える

どのツイートにつけるかissueでは指定されていなかったので、あると便利そうな上記のツイート部分に追加しました。
(もう一つイベント情報が自動でツイートされていますが、イベントのリンクと混ざってしまうと思ったので付け加えませんでした。)

## 確認項目(URLの説明を加えた後にも確認済み)

* [x] 1週間分の予定が7日分入っていたとしても、字数制限を超えない
* [x] toxが通る

## テストの変更

ツイートの文言が変わったので、修正しました。

## サンプルイメージ

### 当日のツイート
![スクリーンショット 2020-10-30 2 57 40](https://user-images.githubusercontent.com/63278411/97613334-e8804a80-1a5b-11eb-9e2b-bf72ef155f7d.png)
![スクリーンショット 2020-10-30 2 58 53](https://user-images.githubusercontent.com/63278411/97613340-ea4a0e00-1a5b-11eb-931b-32fe5292e620.png)

### 1週間分のツイート
![スクリーンショット 2020-10-30 1 28 47](https://user-images.githubusercontent.com/63278411/97613035-87f10d80-1a5b-11eb-86c2-8461a3163f20.png)
![スクリーンショット 2020-10-30 3 01 11](https://user-images.githubusercontent.com/63278411/97613610-39903e80-1a5c-11eb-92e3-eff695642f9a.png)

## URLの説明付きVer
![スクリーンショット 2020-10-30 14 54 36](https://user-images.githubusercontent.com/63278411/97666764-ad186700-1ac1-11eb-9094-b1f7c1018fe1.png)

#### URLの説明付き
![スクリーンショット 2020-10-30 14 52 35](https://user-images.githubusercontent.com/63278411/97666753-a7228600-1ac1-11eb-811c-14bc140c4363.png)