### PR TITLE
Tweet from GitHub Actions

### DIFF
--- a/.github/workflows/notify-daily.yml
+++ b/.github/workflows/notify-daily.yml
@@ -23,3 +23,8 @@ jobs:
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+      - name: Notify to Slack
+        uses: craftech-io/slack-action@v1
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()

--- a/.github/workflows/notify-daily.yml
+++ b/.github/workflows/notify-daily.yml
@@ -1,0 +1,28 @@
+name: CI
+
+# Controls when the action will run. 
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  push: # For debug
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    name: Notify to Twitter (Daily)
+
+    steps:
+      - run: |
+          docker pull camphor/schedule-notifier
+          docker run --rm \
+            -e CSN_API_KEY=$TWITTER_API_KEY \
+            -e CSN_API_SECRET=$TWITTER_API_SECRET \
+            -e CSN_ACCESS_TOKEN=$TWITTER_ACCESS_TOKEN \
+            -e CSN_ACCESS_TOKEN_SECRET=$TWITTER_ACCESS_TOKEN_SECRET \
+            camphor/schedule-notifier \
+            schedule-notifier
+        env:
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}

--- a/.github/workflows/notify-daily.yml
+++ b/.github/workflows/notify-daily.yml
@@ -1,16 +1,14 @@
-name: CI
+name: Notify to Twitter (Daily)
 
-# Controls when the action will run. 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 1 * * *' # At 10:00 am everyday (JST)
   push: # For debug
 
 jobs:
   notify:
     runs-on: ubuntu-latest
     name: Notify to Twitter (Daily)
-
     steps:
       - run: |
           docker pull camphor/schedule-notifier
@@ -20,7 +18,7 @@ jobs:
             -e CSN_ACCESS_TOKEN=$TWITTER_ACCESS_TOKEN \
             -e CSN_ACCESS_TOKEN_SECRET=$TWITTER_ACCESS_TOKEN_SECRET \
             camphor/schedule-notifier \
-            schedule-notifier
+            schedule-notifier --now 2020-12-02
         env:
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}

--- a/.github/workflows/notify-weekly.yml
+++ b/.github/workflows/notify-weekly.yml
@@ -3,7 +3,6 @@ name: Notify to Twitter (Weekly)
 on:
   schedule:
     - cron: '0 1 * * 1' # At 10:00 am every Monday (JST)
-  push:
 
 jobs:
   notify:
@@ -19,7 +18,7 @@ jobs:
             -e CSN_ACCESS_TOKEN_SECRET=$TWITTER_ACCESS_TOKEN_SECRET \
             -e CSN_WEEK=1 \
             camphor/schedule-notifier \
-            schedule-notifier --now 2020-12-01
+            schedule-notifier
         env:
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}

--- a/.github/workflows/notify-weekly.yml
+++ b/.github/workflows/notify-weekly.yml
@@ -24,3 +24,8 @@ jobs:
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+      - name: Notify to Slack
+        uses: craftech-io/slack-action@v1
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()

--- a/.github/workflows/notify-weekly.yml
+++ b/.github/workflows/notify-weekly.yml
@@ -1,13 +1,14 @@
-name: Notify to Twitter (Daily)
+name: Notify to Twitter (Weekly)
 
 on:
   schedule:
-    - cron: '0 1 * * *' # At 10:00 am everyday (JST)
+    - cron: '0 1 * * 1' # At 10:00 am every Monday (JST)
+  push:
 
 jobs:
   notify:
     runs-on: ubuntu-latest
-    name: Notify to Twitter (Daily)
+    name: Notify to Twitter (Weekly)
     steps:
       - run: |
           docker pull camphor/schedule-notifier
@@ -16,8 +17,9 @@ jobs:
             -e CSN_API_SECRET=$TWITTER_API_SECRET \
             -e CSN_ACCESS_TOKEN=$TWITTER_ACCESS_TOKEN \
             -e CSN_ACCESS_TOKEN_SECRET=$TWITTER_ACCESS_TOKEN_SECRET \
+            -e CSN_WEEK=1 \
             camphor/schedule-notifier \
-            schedule-notifier
+            schedule-notifier --now 2020-12-01
         env:
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}


### PR DESCRIPTION
毎日、毎週のツイート送信を GitHub Actions に移した

@KMConner 個人のテスト用アカウントでテストして動作確認済み
https://github.com/camphor-/schedule-notifier/actions/runs/451026393
<img width="593" alt="スクリーンショット 2020-12-30 0 51 38" src="https://user-images.githubusercontent.com/11645979/103296350-41a73300-4a39-11eb-8f3f-aa7d8108a1c3.png">

https://github.com/camphor-/schedule-notifier/actions/runs/451018501
<img width="594" alt="スクリーンショット 2020-12-30 0 51 27" src="https://user-images.githubusercontent.com/11645979/103296378-5257a900-4a39-11eb-9302-ceb99d44ec3a.png">

## TODO

- [ ] Rundeck の Job を無効化
- [x] Secret の更新 (現在は @KMConner  のテストアカウントが入っているのを CAMPHOR- のものに更新する必要がある)
