### PR TITLE
GitHub Actionsで用いるイメージをRegistryから取得する

### DIFF
--- a/.github/workflows/notify-daily.yml
+++ b/.github/workflows/notify-daily.yml
@@ -9,20 +9,29 @@ jobs:
     runs-on: ubuntu-latest
     name: Notify to Twitter (Daily)
     steps:
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.camph.net
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+      - name: Pull and run image from Registry
       - run: |
-          docker pull camphor/schedule-notifier
+          docker pull registry.camph.net/schedule-notifier
           docker run --rm \
             -e CSN_API_KEY=$TWITTER_API_KEY \
             -e CSN_API_SECRET=$TWITTER_API_SECRET \
             -e CSN_ACCESS_TOKEN=$TWITTER_ACCESS_TOKEN \
             -e CSN_ACCESS_TOKEN_SECRET=$TWITTER_ACCESS_TOKEN_SECRET \
-            camphor/schedule-notifier \
+            registry.camph.net/schedule-notifier \
             schedule-notifier
         env:
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+
       - name: Notify to Slack
         uses: craftech-io/slack-action@v1
         with:

--- a/.github/workflows/notify-daily.yml
+++ b/.github/workflows/notify-daily.yml
@@ -17,7 +17,7 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
 
       - name: Pull and run image from Registry
-      - run: |
+        run: |
           docker pull registry.camph.net/schedule-notifier
           docker run --rm \
             -e CSN_API_KEY=$TWITTER_API_KEY \

--- a/.github/workflows/notify-weekly.yml
+++ b/.github/workflows/notify-weekly.yml
@@ -17,7 +17,7 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
 
       - name: Pull and run image from Registry
-      - run: |
+        run: |
           docker pull registry.camph.net/schedule-notifier
           docker run --rm \
             -e CSN_API_KEY=$TWITTER_API_KEY \

--- a/.github/workflows/notify-weekly.yml
+++ b/.github/workflows/notify-weekly.yml
@@ -9,21 +9,30 @@ jobs:
     runs-on: ubuntu-latest
     name: Notify to Twitter (Weekly)
     steps:
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.camph.net
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+      - name: Pull and run image from Registry
       - run: |
-          docker pull camphor/schedule-notifier
+          docker pull registry.camph.net/schedule-notifier
           docker run --rm \
             -e CSN_API_KEY=$TWITTER_API_KEY \
             -e CSN_API_SECRET=$TWITTER_API_SECRET \
             -e CSN_ACCESS_TOKEN=$TWITTER_ACCESS_TOKEN \
             -e CSN_ACCESS_TOKEN_SECRET=$TWITTER_ACCESS_TOKEN_SECRET \
             -e CSN_WEEK=1 \
-            camphor/schedule-notifier \
+            registry.camph.net/schedule-notifier \
             schedule-notifier
         env:
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+
       - name: Notify to Slack
         uses: craftech-io/slack-action@v1
         with:


### PR DESCRIPTION
#35 でDocker Hub からDocker Registryにビルド先を移行した為