### PR TITLE
GitHub Actionsのcronが遅いので早めにしてみる

### DIFF
--- a/.github/workflows/notify-daily.yml
+++ b/.github/workflows/notify-daily.yml
@@ -2,7 +2,7 @@ name: Notify to Twitter (Daily)
 
 on:
   schedule:
-    - cron: '0 23 * * *' # At 10:00 am everyday (JST)
+    - cron: '0 23 * * *' # At 8:00 am everyday (JST)
 
 jobs:
   notify:

--- a/.github/workflows/notify-daily.yml
+++ b/.github/workflows/notify-daily.yml
@@ -2,7 +2,7 @@ name: Notify to Twitter (Daily)
 
 on:
   schedule:
-    - cron: '0 1 * * *' # At 10:00 am everyday (JST)
+    - cron: '0 23 * * *' # At 10:00 am everyday (JST)
 
 jobs:
   notify:

--- a/.github/workflows/notify-weekly.yml
+++ b/.github/workflows/notify-weekly.yml
@@ -2,7 +2,7 @@ name: Notify to Twitter (Weekly)
 
 on:
   schedule:
-    - cron: '0 1 * * 1' # At 10:00 am every Monday (JST)
+    - cron: '0 23 * * 1' # At 8:00 am every Monday (JST)
 
 jobs:
   notify:


### PR DESCRIPTION
タイトルの通り。ツイートが遅れがちなのでGitHub Actionsの時間を早める