### PR TITLE
dependabot を導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Japan
+    open-pull-requests-limit: 10
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Japan
+    open-pull-requests-limit: 10
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Japan
+    open-pull-requests-limit: 10


### PR DESCRIPTION
GitHub Actions の Cron Job が停止されないようにするため


ref: [GitHub Actions は60日間リポジトリに活動が無いと自動停止する](https://zenn.dev/hellorusk/articles/fc6d4696f5b269)

> なので、もし完全に自動化したい場合は、おそらく 2ヶ月（以内）に1回何かしらの無駄なコミットをする ことで、Cron Job の自動停止も回避できるのではないかと思います（まだ自分は試していませんが...）。自動コミット用の GitHub Actions が別にあるので、それを使えば良いでしょう。
>
> あるいは [dependabot](https://dependabot.com/) のような、依存パッケージのバージョン監視botを導入して、2ヶ月（以内）に1回プルリクエストを送ってもらうようにすればいいですね。